### PR TITLE
docs(readme): Change a typo in the ssh_key_path variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ resource "profitbricks_volume" "example" {
   image_name = "${var.ubuntu}"
   size = 5
   disk_type = "HDD"
-  sshkey_path = "${var.private_key_path}"
+  ssh_key_path = "${var.ssh_keys}"
   bus = "VIRTIO"
   availablity_zone = "ZONE_1"
 }
@@ -687,8 +687,8 @@ resource "profitbricks_volume" "example" {
 | disk_type | Yes | string | The storage volume type. ["HDD", or "SSD"] |
 | bus | Yes | string | The bus type of the storage volume. ["VIRTIO", or "IDE"] |
 | size |  Yes | integer | The size of the storage volume in GB. |
-| image_password | Yes* | string | Password set for the `root` or `Administrator` user on ProfitBricks provided images. Required if `sshkey_path` is not provided. |
-| sshkey_path | Yes* | string | Path to a file containing a public SSH key that will be injected into ProfitBricks provided Linux images. Required if `image_password` is not provided. |
+| image_password | Yes* | string | Password set for the `root` or `Administrator` user on ProfitBricks provided images. Required if `ssh_key_path` is not provided. |
+| ssh_key_path | Yes* | string | Path to a file containing a public SSH key that will be injected into ProfitBricks provided Linux images. Required if `image_password` is not provided. |
 | image_name | Yes* | string | The image or snapshot UUID. It is required if `licence_type` is not provided. |
 | licence_type | Yes* |string | Required if `image_name` is not provided. ["LINUX", "WINDOWS", or "OTHER"] |
 | name | No | string | A name for the storage volume. |


### PR DESCRIPTION
I think there is also a typo in the documentation